### PR TITLE
Update python_version for 3.13

### DIFF
--- a/generator.json
+++ b/generator.json
@@ -15,7 +15,7 @@
     "latest_tested_versions": [
         "Splunk SOAR 6.2.2.134"
     ],
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "logo": "logo_generator.svg",
     "logo_dark": "logo_generator_dark.svg",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Resolved app issues related to Python 3.13 upgrade
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)