### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Generator
 
-Publisher: Splunk \
-Connector Version: 4.0.711 \
-Product Vendor: Generic \
-Product Name: Generator \
+Publisher: Splunk <br>
+Connector Version: 4.0.711 <br>
+Product Vendor: Generic <br>
+Product Name: Generator <br>
 Minimum Product Version: 6.2.1
 
 This app generates ingested sample data
@@ -154,14 +154,14 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
 [on poll](#action-on-poll) - Callback action for the on_poll ingest functionality
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -176,7 +176,7 @@ No Output
 
 Callback action for the on_poll ingest functionality
 
-Type: **ingest** \
+Type: **ingest** <br>
 Read only: **True**
 
 #### Action Parameters

--- a/generator.json
+++ b/generator.json
@@ -15,7 +15,7 @@
     "latest_tested_versions": [
         "Splunk SOAR 6.2.2.134"
     ],
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "logo": "logo_generator.svg",
     "logo_dark": "logo_generator_dark.svg",

--- a/generator.json
+++ b/generator.json
@@ -181,5 +181,11 @@
             "output": [],
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 * Resolved app issues related to Python 3.13 upgrade
 * Resolved e0006 issue related to Python 3.13 upgrade
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)